### PR TITLE
Accessing the API via the tld will stop working soon

### DIFF
--- a/lib/manifestly/http/client.rb
+++ b/lib/manifestly/http/client.rb
@@ -2,7 +2,7 @@ require 'faraday'
 
 module Manifestly
   class Client
-    DEFAULT_URL = 'https://manifest.ly/api'.freeze
+    DEFAULT_URL = 'https://api.manifest.ly/api'.freeze
     DEFAULT_API_VERSION = 'v1'.freeze
 
     attr_reader :url, :api_version, :api_key


### PR DESCRIPTION
### Summary

The Manifestly API is currently accessible via the top-level domain (**manifest.ly**). We are extracting our marketing site from our app/api. Once we cutover to the new marketing site, the API will no longer be available via the top-level domain. As of now, the API is available at **api.manifest.ly**. Please switch to that.